### PR TITLE
Allow using subfolders in local driver

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,3 +11,5 @@ Contributors
 ============
 
 .. * <contributor-name-here>
+
+* James Stewart `@JamesStewy <https://github.com/JamesStewy>`_

--- a/src/cloudstorage/drivers/local.py
+++ b/src/cloudstorage/drivers/local.py
@@ -360,7 +360,7 @@ class LocalDriver(Driver):
         created_at = datetime.fromtimestamp(stat.st_ctime, timezone.utc)
         modified_at = datetime.fromtimestamp(stat.st_mtime, timezone.utc)
 
-        return Blob(name=object_path.name, checksum=checksum, etag=etag,
+        return Blob(name=object_name, checksum=checksum, etag=etag,
                     size=stat.st_size, container=container, driver=self,
                     acl=None, meta_data=meta_data,
                     content_disposition=content_disposition,


### PR DESCRIPTION
This changes allows the use of subfolders inside a local driver container.

Using `object_path.name` removes any folders specified in `object_name`.