### PR TITLE
Allow pull requests to ignore missing secret and keys for drivers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: false
 cache: pip
 before_install:
   - |
-      if [ -f gcs-service-account.json.enc ]; then
-        openssl aes-256-cbc -K $encrypted_12e75a453f27_key -iv $encrypted_12e75a453f27_iv -in gcs-service-account.json.enc -out gcs-service-account.json -d;
-      fi
+    if [ -z ${encrypted_12e75a453f27_key+x} ]; then
+      openssl aes-256-cbc -K $encrypted_12e75a453f27_key -iv $encrypted_12e75a453f27_iv -in gcs-service-account.json.enc -out gcs-service-account.json -d;
+    fi
 install:
   - pip install tox
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,18 @@
 language: python
 sudo: false
 cache: pip
-before_install:
-  - if [ -z ${encrypted_12e75a453f27_key+x} ]; then
+
+install:
+  - pip install tox
+script:
+  - tox -v
+  - |
+    if [ -z ${encrypted_12e75a453f27_key+x} ]; then
       echo "Decrypting gcs-service-account.json.enc";
       openssl aes-256-cbc -K $encrypted_12e75a453f27_key -iv $encrypted_12e75a453f27_iv -in gcs-service-account.json.enc -out gcs-service-account.json -d;
     else
       echo "gcs-service-account.json.enc not found!"
     fi
-install:
-  - pip install tox
-script:
-  - tox -v
 
 jobs:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,10 @@ cache: pip
 before_install:
   - |
     if [ -z ${encrypted_12e75a453f27_key+x} ]; then
+      echo "Decrypting gcs-service-account.json.enc";
       openssl aes-256-cbc -K $encrypted_12e75a453f27_key -iv $encrypted_12e75a453f27_iv -in gcs-service-account.json.enc -out gcs-service-account.json -d;
+    else
+      echo "gcs-service-account.json.enc not found!"
     fi
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: python
 sudo: false
 cache: pip
 before_install:
-  - |
-    if [ -z ${encrypted_12e75a453f27_key+x} ]; then
+  - if [ -z ${encrypted_12e75a453f27_key+x} ]; then
       echo "Decrypting gcs-service-account.json.enc";
       openssl aes-256-cbc -K $encrypted_12e75a453f27_key -iv $encrypted_12e75a453f27_iv -in gcs-service-account.json.enc -out gcs-service-account.json -d;
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,10 @@ language: python
 sudo: false
 cache: pip
 before_install:
-  - openssl aes-256-cbc -K $encrypted_12e75a453f27_key -iv $encrypted_12e75a453f27_iv -in gcs-service-account.json.enc -out gcs-service-account.json -d
+  - |
+      if [ -f gcs-service-account.json.enc ]; then
+        openssl aes-256-cbc -K $encrypted_12e75a453f27_key -iv $encrypted_12e75a453f27_iv -in gcs-service-account.json.enc -out gcs-service-account.json -d;
+      fi
 install:
   - pip install tox
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ install:
 script:
   - tox -v
   - |
-    if [ -z ${encrypted_12e75a453f27_key+x} ]; then
+    if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then
       echo "Decrypting gcs-service-account.json.enc";
       openssl aes-256-cbc -K $encrypted_12e75a453f27_key -iv $encrypted_12e75a453f27_iv -in gcs-service-account.json.enc -out gcs-service-account.json -d;
     else
-      echo "gcs-service-account.json.enc not found!"
+      echo "Skipping decryption of gcs-service-account.json.enc"
     fi
 
 jobs:

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -48,8 +48,6 @@ GOOGLE_CREDENTIALS = config('GOOGLE_CREDENTIALS', default=None,
                             cast=lambda path: os.path.abspath(path))
 
 LOCAL_KEY = config('LOCAL_KEY', default=mkdtemp(prefix='cloud-storage-test-'))
-if not os.path.exists(LOCAL_KEY):
-    os.makedirs(LOCAL_KEY)
 LOCAL_SECRET = config('LOCAL_SECRET', default='local-storage-secret')
 
 RACKSPACE_KEY = config('RACKSPACE_KEY', default=None)

--- a/tests/test_drivers_google.py
+++ b/tests/test_drivers_google.py
@@ -1,4 +1,5 @@
 import random
+import os
 
 try:
     from http import HTTPStatus
@@ -20,7 +21,7 @@ from cloudstorage.helpers import file_checksum
 from tests.helpers import random_container_name, uri_validator, rate_limited
 from tests.settings import *
 
-pytestmark = pytest.mark.skipif(not bool(GOOGLE_CREDENTIALS),
+pytestmark = pytest.mark.skipif(not os.path.isfile(GOOGLE_CREDENTIALS),
                                 reason='settings missing key and secret')
 
 

--- a/tests/test_drivers_local.py
+++ b/tests/test_drivers_local.py
@@ -1,4 +1,5 @@
 import shutil
+import os
 
 import pytest
 
@@ -12,8 +13,11 @@ from cloudstorage.exceptions import (
 from tests.helpers import random_container_name, uri_validator
 from tests.settings import *
 
-pytestmark = pytest.mark.skipif(not bool(LOCAL_KEY),
-                                reason='settings missing key and secret')
+if not os.path.exists(LOCAL_KEY):
+    os.makedirs(LOCAL_KEY)
+
+pytestmark = pytest.mark.skipif(not os.path.isdir(LOCAL_KEY),
+                                reason='Directory does not exist.')
 
 
 @pytest.fixture(scope='module')

--- a/tests/test_drivers_local.py
+++ b/tests/test_drivers_local.py
@@ -13,7 +13,7 @@ from cloudstorage.exceptions import (
 from tests.helpers import random_container_name, uri_validator
 from tests.settings import *
 
-if not os.path.exists(LOCAL_KEY):
+if LOCAL_KEY and not os.path.exists(LOCAL_KEY):
     os.makedirs(LOCAL_KEY)
 
 pytestmark = pytest.mark.skipif(not os.path.isdir(LOCAL_KEY),


### PR DESCRIPTION
Temporary fixes #38 by checking for encrypted environment variables before trying to decrypt `gcs-service-account.json.enc`. See #39 for complete solution.