### PR TITLE
allow using aws_session_token in s3 driver

### DIFF
--- a/src/cloudstorage/drivers/amazon.py
+++ b/src/cloudstorage/drivers/amazon.py
@@ -64,12 +64,14 @@ class S3Driver(Driver):
     url = 'https://aws.amazon.com/s3/'
 
     def __init__(self, key: str, secret: str = None, region: str = 'us-east-1',
+                 token: str = None,
                  **kwargs: Dict) -> None:
         region = region.lower()
         super().__init__(key=key, secret=secret, region=region, **kwargs)
 
         self._session = boto3.Session(aws_access_key_id=key,
                                       aws_secret_access_key=secret,
+                                      aws_session_token=token,
                                       region_name=region)
 
         # session required for loading regions list

--- a/src/cloudstorage/drivers/amazon.py
+++ b/src/cloudstorage/drivers/amazon.py
@@ -56,6 +56,9 @@ class S3Driver(Driver):
     :param region: (optional) Region to connect to. Defaults to `us-east-1`.
     :type region: str
 
+    :param token: (optional) AWS Session Token
+    :type token: str
+
     :param kwargs: (optional) Extra driver options.
     :type kwargs: dict
     """
@@ -64,14 +67,13 @@ class S3Driver(Driver):
     url = 'https://aws.amazon.com/s3/'
 
     def __init__(self, key: str, secret: str = None, region: str = 'us-east-1',
-                 token: str = None,
                  **kwargs: Dict) -> None:
         region = region.lower()
         super().__init__(key=key, secret=secret, region=region, **kwargs)
 
         self._session = boto3.Session(aws_access_key_id=key,
                                       aws_secret_access_key=secret,
-                                      aws_session_token=token,
+                                      aws_session_token=kwargs.get('token'),
                                       region_name=region)
 
         # session required for loading regions list


### PR DESCRIPTION
Hi,

I'm using this library in AWS Lambda, it works great but Lambda requires also a token called "aws_session_token" to authenticate.

I've added that in this PR.

Right now I'm doing this:
```
driver = S3Driver(
    key=environ.get('AWS_ACCESS_KEY_ID'),
    secret=environ.get('AWS_SECRET_ACCESS_KEY')
)
driver._session = Session(
    aws_access_key_id=environ.get('AWS_ACCESS_KEY_ID'),
    aws_secret_access_key=environ.get('AWS_SECRET_ACCESS_KEY'),
    aws_session_token=environ.get('AWS_SESSION_TOKEN')
)
```