### PR TITLE
Rewind stream after it's been read for hashing, allowing later re-read

### DIFF
--- a/src/cloudstorage/helpers.py
+++ b/src/cloudstorage/helpers.py
@@ -75,6 +75,9 @@ def file_checksum(filename: FileLike, hash_type: str = 'md5',
     else:
         for chunk in read_in_chunks(filename, block_size=block_size):
             file_hash.update(chunk)
+        # rewind the stream so it can be re-read later
+        if filename.seekable():
+            filename.seek(0)
 
     return file_hash
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -45,7 +45,7 @@ AZURE_ACCOUNT_NAME = config('AZURE_ACCOUNT_NAME', default=None)
 AZURE_ACCOUNT_KEY = config('AZURE_ACCOUNT_KEY', default=None)
 
 GOOGLE_CREDENTIALS = config('GOOGLE_CREDENTIALS', default=None,
-                            cast=lambda path: os.path.abspath(path))
+                            cast=lambda path: os.path.abspath(path) if path else None)
 
 LOCAL_KEY = config('LOCAL_KEY', default=mkdtemp(prefix='cloud-storage-test-'))
 LOCAL_SECRET = config('LOCAL_SECRET', default='local-storage-secret')

--- a/tests/test_drivers_google.py
+++ b/tests/test_drivers_google.py
@@ -21,8 +21,9 @@ from cloudstorage.helpers import file_checksum
 from tests.helpers import random_container_name, uri_validator, rate_limited
 from tests.settings import *
 
-pytestmark = pytest.mark.skipif(not os.path.isfile(GOOGLE_CREDENTIALS),
-                                reason='settings missing key and secret')
+pytestmark = pytest.mark.skipif(
+    not bool(GOOGLE_CREDENTIALS) or not os.path.isfile(GOOGLE_CREDENTIALS),
+    reason='settings missing key and secret')
 
 
 @pytest.fixture(scope='module')

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -19,9 +19,15 @@ def test_read_in_chunks(binary_stream):
     assert sum(1 for _ in data) == total_chunks_read
 
 
-def test_file_checksum(text_filename):
+def test_file_checksum_filename(text_filename):
     file_hash = file_checksum(text_filename, hash_type='md5', block_size=32)
     assert file_hash.hexdigest() == TEXT_MD5_CHECKSUM
+
+
+def test_file_checksum_stream(binary_stream):
+    file_hash = file_checksum(binary_stream, hash_type='md5', block_size=32)
+    assert file_hash.hexdigest() == BINARY_MD5_CHECKSUM
+    assert binary_stream.tell() == 0
 
 
 def test_validate_file_or_path(text_filename, binary_stream):


### PR DESCRIPTION
Also fixed test bug when google credentials file not present

Fixes https://github.com/scottwernervt/cloudstorage/issues/44