### PR TITLE
Skip md5 validation if the remote blob didn't send a checksum

### DIFF
--- a/src/cloudstorage/drivers/microsoft.py
+++ b/src/cloudstorage/drivers/microsoft.py
@@ -152,14 +152,18 @@ class AzureStorageDriver(Driver):
         """
         content_settings = azure_blob.properties.content_settings
 
-        # TODO: CODE: Move to helper since google uses it too.
-        md5_bytes = base64.b64decode(content_settings.content_md5)
+        if content_settings.content_md5:
+            # TODO: CODE: Move to helper since google uses it too.
+            md5_bytes = base64.b64decode(content_settings.content_md5)
 
-        try:
-            checksum = md5_bytes.hex()
-        except AttributeError:
-            # Python 3.4: 'bytes' object has no attribute 'hex'
-            checksum = codecs.encode(md5_bytes, 'hex_codec').decode('ascii')
+            try:
+                checksum = md5_bytes.hex()
+            except AttributeError:
+                # Python 3.4: 'bytes' object has no attribute 'hex'
+                checksum = codecs.encode(md5_bytes, 'hex_codec').decode('ascii')
+        else:
+            logger.warning('Content MD5 not populated, content will not be validated')
+            checksum = None
 
         return Blob(name=azure_blob.name,
                     size=azure_blob.properties.content_length,


### PR DESCRIPTION
If a blob was uploaded through other means without a Content-MD5 header, azure will not populate that header automatically, and it will not be returned when the blob is downloaded. This change skips the checksum validation if the header is missing (avoiding the resultant TypeError) and logs an appropriate warning

Fixes #47 