### PR TITLE
Make google application credentials file optional

### DIFF
--- a/src/cloudstorage/drivers/google.py
+++ b/src/cloudstorage/drivers/google.py
@@ -92,9 +92,11 @@ class GoogleStorageDriver(Driver):
 
         if key:
             os.environ[self._CREDENTIALS_ENV_NAME] = key
+        else:
+            logger.debug('No key provided, attempting to authenticate with Google Metadata API')
 
         google_application_credentials = os.getenv(self._CREDENTIALS_ENV_NAME)
-        if not os.path.isfile(google_application_credentials):
+        if google_application_credentials and not os.path.isfile(google_application_credentials):
             raise CredentialsError(
                 "Please set environment variable "
                 "'GOOGLE_APPLICATION_CREDENTIALS' or provider file path "


### PR DESCRIPTION
The google application credentials file is not required when the application is running inside google Compute or App engine. This change will not raise an error in the case that the credentials file is missing

Fixes #51 