### PR TITLE
Windows compatibility for LOCAL driver

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
         'local': [
             'filelock>=3.0.0',  # Public Domain
             'itsdangerous>=1.1.0',  # BSD License
-            'xattr>=0.9.6',  # MIT
+            'xattr>=0.9.6; sys_platform != "win32"',  # MIT
         ],
         'microsoft': [
             'azure>=4.0.0',  # MIT

--- a/tests/test_drivers_local.py
+++ b/tests/test_drivers_local.py
@@ -150,6 +150,26 @@ def test_blob_upload_path(container, text_filename):
     assert blob.checksum == TEXT_MD5_CHECKSUM
 
 
+def test_blob_windows_xattr(container, text_filename):
+    if os.name != 'nt':
+        pytest.skip("skipping Windows-only test")
+    blob = container.upload_blob(text_filename, meta_data={'test': 'testvalue'})
+    try:
+        internal_blob = container.get_blob('.{}.xattr'.format(TEXT_FILENAME))
+        pytest.fail('should not be possible to get internal xattr file')
+    except NotFoundError:
+        pass
+
+
+def test_blob_windows_xattr_list(container, text_filename):
+    if os.name != 'nt':
+        pytest.skip("skipping Windows-only test")
+    blob = container.upload_blob(text_filename, meta_data={'test': 'testvalue'})
+    for blobitem in container:
+        if blobitem.name.startswith('.') and blobitem.name.endswith('.xattr'):
+            pytest.fail('should not be possible to get internal xattr file')
+
+
 def test_blob_upload_stream(container, binary_stream):
     blob = container.upload_blob(filename=binary_stream,
                                  blob_name=BINARY_STREAM_FILENAME,

--- a/tests/test_drivers_local.py
+++ b/tests/test_drivers_local.py
@@ -37,6 +37,8 @@ def storage():
 
 
 def test_driver_validate_credentials():
+    if os.name == 'nt':
+        pytest.skip("skipping Windows incompatible test")
     driver = LocalDriver(key=LOCAL_KEY)
     assert driver.validate_credentials() is None
 


### PR DESCRIPTION
The LOCAL driver isn't Windows compatible because it uses xattr for attributes, which isn't available in Windows.
To simulate this in windows, a JSON file named ".<filename>.xattr" is created in the same directory as the main file, with the file attributes.
Also this file cannot be accessed by the other methods, so it is filtered.
This is not a very performant way of doing this, but the LOCAL driver is normally for testing purposes only, so this should be sufficient.