### PR TITLE
Handle pathlib.Path properly

### DIFF
--- a/src/cloudstorage/base.py
+++ b/src/cloudstorage/base.py
@@ -2,6 +2,7 @@ import abc
 import logging
 from abc import abstractmethod
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Union  # noqa: F401
 
 from cloudstorage import messages
@@ -252,6 +253,8 @@ class Blob:
 
         :raises NotFoundError: If the blob object doesn't exist.
         """
+        if isinstance(destination, Path):
+            destination = str(destination)
         self.driver.download_blob(self, destination)
 
     def generate_download_url(
@@ -698,6 +701,8 @@ class Container:
         :return: The uploaded blob.
         :rtype: Blob
         """
+        if isinstance(filename, Path):
+            filename = str(filename)
         return self.driver.upload_blob(
             container=self,
             filename=filename,

--- a/src/cloudstorage/typed.py
+++ b/src/cloudstorage/typed.py
@@ -1,4 +1,5 @@
 """Custom typed annotations."""
+from pathlib import Path
 from typing import Any, BinaryIO, Dict, Optional, TYPE_CHECKING, TextIO, Union, Type
 
 if TYPE_CHECKING:
@@ -19,7 +20,7 @@ Drivers = Union[
     Type["MinioDriver"],
     Type["CloudFilesDriver"],
 ]
-FileLike = Union[BinaryIO, TextIO, str]
+FileLike = Union[BinaryIO, TextIO, str, Path]
 Acl = Optional[Dict[Any, Any]]
 MetaData = Optional["CaseInsensitiveDict"]
 ExtraOptions = Optional[Dict[Any, Any]]

--- a/tests/test_drivers_amazon.py
+++ b/tests/test_drivers_amazon.py
@@ -2,6 +2,7 @@ from http import HTTPStatus
 
 import pytest
 import requests
+from pathlib import Path
 
 from cloudstorage.drivers.amazon import S3Driver
 from cloudstorage.exceptions import (
@@ -164,6 +165,12 @@ def test_blob_upload_path(container, text_filename):
     assert blob.checksum == settings.TEXT_MD5_CHECKSUM
 
 
+def test_blob_upload_pathlib_path(container, text_filename):
+    blob = container.upload_blob(Path(text_filename))
+    assert blob.name == settings.TEXT_FILENAME
+    assert blob.checksum == settings.TEXT_MD5_CHECKSUM
+
+
 def test_blob_upload_stream(container, binary_stream):
     blob = container.upload_blob(
         filename=binary_stream,
@@ -195,6 +202,13 @@ def test_blob_delete(container, text_blob):
 
 def test_blob_download_path(binary_blob, temp_file):
     binary_blob.download(temp_file)
+    hash_type = binary_blob.driver.hash_type
+    download_hash = file_checksum(temp_file, hash_type=hash_type)
+    assert download_hash.hexdigest() == settings.BINARY_MD5_CHECKSUM
+
+
+def test_blob_download_pathlib_path(binary_blob, temp_file):
+    binary_blob.download(Path(temp_file))
     hash_type = binary_blob.driver.hash_type
     download_hash = file_checksum(temp_file, hash_type=hash_type)
     assert download_hash.hexdigest() == settings.BINARY_MD5_CHECKSUM


### PR DESCRIPTION
Since Python 3.4 the `pathlib` standard library offers an object-oriented representation of paths. `pathlib.Path` should be handled the same way str paths are, but currently `Blob.download` and `Container.upload_blob` would consider them file-like objects as they are not strings.

(I'm adding tests only to `test_driver_amazon.py` since really it's implemented in `base.py`).