### PR TITLE
Fix the windows Xattr simulator to convert bytes to str before saving the json file

### DIFF
--- a/src/cloudstorage/drivers/local.py
+++ b/src/cloudstorage/drivers/local.py
@@ -702,6 +702,8 @@ class XattrWindows:
         Write an attribute to the json file.
         """
         data = self._load()
+        if isinstance(value, bytes):
+            value = value.decode('utf-8')
         data[key] = value
         with open(self.xattr_filename, "w") as outfile:
             json.dump(data, outfile)


### PR DESCRIPTION
The simplexml library I used on the initial PR already handled this, as this was changed to use the core json library, this check must be made before encoding.