### PR TITLE
DigitalOcean Spaces driver

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -15,3 +15,4 @@ Contributors
 * James Stewart `@JamesStewy <https://github.com/JamesStewy>`_
 * Matt Carr `@matt-carr <https://github.com/matt-carr>`_
 * Sibo Wang `@sibowsb <https://github.com/sibowsb>`_
+* Rangel Reale `@RangelReale <https://github.com/RangelReale>`_

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ INSTALL_REQUIRES = [
 ]
 EXTRAS_REQUIRE = {
     "amazon": ["boto3>=1.8.00", "boto3-stubs[s3]>==1.12.41.0"],
+    "digitalocean": ["boto3>=1.8.00", "boto3-stubs[s3]>==1.12.41.0"],
     "google": ["google-cloud-storage>=1.18.0", "requests>=2.19.1"],
     "local": [
         "filelock>=3.0.0",

--- a/src/cloudstorage/__init__.py
+++ b/src/cloudstorage/__init__.py
@@ -36,6 +36,7 @@ class DriverName(Enum):
     LOCAL = "LOCAL"
     MINIO = "MINIO"
     S3 = "S3"
+    DIGITALOCEANSPACES = "DIGITALOCEANSPACES"
 
 
 _DRIVER_IMPORTS = {
@@ -45,6 +46,7 @@ _DRIVER_IMPORTS = {
     DriverName.LOCAL: ("cloudstorage.drivers.local", "LocalDriver"),
     DriverName.MINIO: ("cloudstorage.drivers.minio", "MinioDriver"),
     DriverName.S3: ("cloudstorage.drivers.amazon", "S3Driver"),
+    DriverName.DIGITALOCEANSPACES: ("cloudstorage.drivers.digitalocean", "DigitalOceanSpacesDriver"),
 }
 
 
@@ -63,7 +65,7 @@ def get_driver(driver: DriverName) -> Drivers:
     :return: DriverName driver class.
     :rtype: :class:`.AzureStorageDriver`, :class:`.CloudFilesDriver`,
       :class:`.GoogleStorageDriver`, :class:`.S3Driver`, :class:`.LocalDriver`,
-      :class:`.MinioDriver`
+      :class:`.MinioDriver`, :class:`.DigitalOceanSpacesDriver`
     """
     if driver in _DRIVER_IMPORTS:
         mod_name, driver_name = _DRIVER_IMPORTS[driver]
@@ -90,12 +92,13 @@ def get_driver_by_name(driver_name: str) -> Drivers:
         * `S3`
         * `LOCAL`
         * `MINIO`
+        * `DIGITALOCEANSPACES`
     :type driver_name: str
 
     :return: DriverName driver class.
     :rtype: :class:`.AzureStorageDriver`, :class:`.CloudFilesDriver`,
       :class:`.GoogleStorageDriver`, :class:`.S3Driver`, :class:`.LocalDriver`,
-      :class:`.MinioDriver`
+      :class:`.MinioDriver`, :class:`.DigitalOceanSpacesDriver`
     """
     driver = DriverName[driver_name]
     return get_driver(driver)

--- a/src/cloudstorage/__init__.py
+++ b/src/cloudstorage/__init__.py
@@ -46,7 +46,10 @@ _DRIVER_IMPORTS = {
     DriverName.LOCAL: ("cloudstorage.drivers.local", "LocalDriver"),
     DriverName.MINIO: ("cloudstorage.drivers.minio", "MinioDriver"),
     DriverName.S3: ("cloudstorage.drivers.amazon", "S3Driver"),
-    DriverName.DIGITALOCEANSPACES: ("cloudstorage.drivers.digitalocean", "DigitalOceanSpacesDriver"),
+    DriverName.DIGITALOCEANSPACES: (
+        "cloudstorage.drivers.digitalocean",
+        "DigitalOceanSpacesDriver",
+    ),
 }
 
 

--- a/src/cloudstorage/drivers/amazon.py
+++ b/src/cloudstorage/drivers/amazon.py
@@ -224,6 +224,19 @@ class S3Driver(Driver):
             created_at=created_at,
         )
 
+    def _create_bucket_params(self, params: Dict[Any, Any]) -> Dict[Any, Any]:
+        """Process extra create bucket params.
+
+        :param params: Default create bucket parameters.
+        :return: Final create bucket parameters.
+        """
+        # TODO: BUG: Creating S3 bucket in us-east-1
+        if self.region != "us-east-1":
+            params["CreateBucketConfiguration"] = {
+                "LocationConstraint": self.region,
+            }
+        return params
+
     @property
     def session(self) -> boto3.session.Session:
         """Amazon Web Services session.
@@ -267,12 +280,7 @@ class S3Driver(Driver):
         if acl:
             params["ACL"] = acl.lower()
 
-        # TODO: BUG: Creating S3 bucket in us-east-1
-        # See https://github.com/boto/boto3/issues/125
-        if self.region != "us-east-1":
-            params["CreateBucketConfiguration"] = {
-                "LocationConstraint": self.region,
-            }
+        params = self._create_bucket_params(params)
 
         logger.debug("params=%s", params)
 

--- a/src/cloudstorage/drivers/digitalocean.py
+++ b/src/cloudstorage/drivers/digitalocean.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, Iterable, List
+from typing import Dict, List
 
 import boto3
 
@@ -53,7 +53,7 @@ class DigitalOceanSpacesDriver(S3Driver):
 
     @property
     def regions(self) -> List[str]:
-        return ['nyc3', 'ams3', 'sfo2', 'sgp1', 'fra1']
+        return ["nyc3", "ams3", "sfo2", "sgp1", "fra1"]
 
     # noinspection PyUnresolvedReferences
     @property
@@ -63,5 +63,8 @@ class DigitalOceanSpacesDriver(S3Driver):
         :return: The s3 resource instance.
         :rtype: :class:`boto3.resources.base.ServiceResource`
         """
-        return self.session.resource(service_name="s3", region_name=self.region,
-                                     endpoint_url=f"https://{self.region}.digitaloceanspaces.com")
+        return self.session.resource(
+            service_name="s3",
+            region_name=self.region,
+            endpoint_url=f"https://{self.region}.digitaloceanspaces.com",
+        )

--- a/src/cloudstorage/drivers/digitalocean.py
+++ b/src/cloudstorage/drivers/digitalocean.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List
+from typing import Dict, List, Any
 
 import boto3
 
@@ -51,8 +51,13 @@ class DigitalOceanSpacesDriver(S3Driver):
     ) -> None:
         super().__init__(key, secret, region, **kwargs)
 
+    def _create_bucket_params(self, params: Dict[Any, Any]) -> Dict[Any, Any]:
+        return params
+
     @property
     def regions(self) -> List[str]:
+        """List of DigitalOcean regions that support Spaces.
+        """
         return ["nyc3", "ams3", "sfo2", "sgp1", "fra1"]
 
     # noinspection PyUnresolvedReferences
@@ -68,3 +73,7 @@ class DigitalOceanSpacesDriver(S3Driver):
             region_name=self.region,
             endpoint_url=f"https://{self.region}.digitaloceanspaces.com",
         )
+
+    def validate_credentials(self) -> None:
+        # Not available
+        pass

--- a/src/cloudstorage/drivers/digitalocean.py
+++ b/src/cloudstorage/drivers/digitalocean.py
@@ -1,0 +1,67 @@
+import logging
+from typing import Dict, Iterable, List
+
+import boto3
+
+from cloudstorage.drivers.amazon import S3Driver
+
+__all__ = ["DigitalOceanSpacesDriver"]
+
+logger = logging.getLogger(__name__)
+
+
+class DigitalOceanSpacesDriver(S3Driver):
+    """Driver for interacting with DigitalOcean Spaces Service.
+    DigitalOcean spaces uses an S3-compatible API, this drivers extends the
+    S3 driver to implement API differences.
+
+    .. code-block:: python
+
+        from cloudstorage.drivers.digitalocean import DigitalOceanSpacesDriver
+
+        storage = DigitalOceanSpacesDriver(key='<my-digitalocean-access-key-id>',
+                   secret='<my-digitalocean-secret-access-key>',
+                   region='sfo2')
+        # <Driver: S3 us-east-1>
+
+    References:
+
+    * `DigitalOcean Spaces API
+      <https://developers.digitalocean.com/documentation/spaces/>`_
+
+    :param key: DigitalOcean Access Key ID.
+    :type key: str
+
+    :param secret: DigitalOcean Secret Access Key.
+    :type secret: str
+
+    :param region: (optional) Region to connect to. Defaults to `sfo2`.
+    :type region: str
+
+    :param kwargs: (optional) Extra driver options.
+    :type kwargs: dict
+    """
+
+    name = "DIGITALOCEANSPACES"
+    hash_type = "md5"
+    url = "https://www.digitalocean.com/products/spaces/"
+
+    def __init__(
+        self, key: str, secret: str = None, region: str = "sfo2", **kwargs: Dict
+    ) -> None:
+        super().__init__(key, secret, region, **kwargs)
+
+    @property
+    def regions(self) -> List[str]:
+        return ['nyc3', 'ams3', 'sfo2', 'sgp1', 'fra1']
+
+    # noinspection PyUnresolvedReferences
+    @property
+    def s3(self) -> boto3.resources.base.ServiceResource:
+        """S3 service resource.
+
+        :return: The s3 resource instance.
+        :rtype: :class:`boto3.resources.base.ServiceResource`
+        """
+        return self.session.resource(service_name="s3", region_name=self.region,
+                                     endpoint_url=f"https://{self.region}.digitaloceanspaces.com")

--- a/src/cloudstorage/drivers/local.py
+++ b/src/cloudstorage/drivers/local.py
@@ -703,7 +703,7 @@ class XattrWindows:
         """
         data = self._load()
         if isinstance(value, bytes):
-            value = value.decode('utf-8')
+            value = value.decode("utf-8")
         data[key] = value
         with open(self.xattr_filename, "w") as outfile:
             json.dump(data, outfile)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,6 +72,9 @@ def binary_blob(container, binary_filename):
 
 @pytest.fixture(scope="function")
 def temp_file():
-    _, path = mkstemp(prefix=settings.CONTAINER_PREFIX)
+    fd, path = mkstemp(prefix=settings.CONTAINER_PREFIX)
+    if os.name == "nt":
+        # Must close in Windows, otherwise errors as file being used
+        os.close(fd)
     yield path
     os.remove(path)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -43,6 +43,10 @@ AMAZON_KEY = config("AMAZON_KEY", default=None)
 AMAZON_SECRET = config("AMAZON_SECRET", default=None)
 AMAZON_REGION = config("AMAZON_REGION", default="us-east-1")
 
+DIGITALOCEAN_KEY = config("DIGITALOCEAN_KEY", default=None)
+DIGITALOCEAN_SECRET = config("DIGITALOCEAN_SECRET", default=None)
+DIGITALOCEAN_REGION = config("DIGITALOCEAN_REGION", default="sfo2")
+
 AZURE_ACCOUNT_NAME = config("AZURE_ACCOUNT_NAME", default=None)
 AZURE_ACCOUNT_KEY = config("AZURE_ACCOUNT_KEY", default=None)
 

--- a/tests/test_drivers_digitalocean.py
+++ b/tests/test_drivers_digitalocean.py
@@ -1,0 +1,246 @@
+from http import HTTPStatus
+
+import pytest
+import requests
+from pathlib import Path
+
+from cloudstorage.drivers.digitalocean import DigitalOceanSpacesDriver
+from cloudstorage.exceptions import (
+    CloudStorageError,
+    IsNotEmptyError,
+    NotFoundError,
+)
+from cloudstorage.helpers import file_checksum
+from tests import settings
+from tests.helpers import random_container_name, uri_validator
+
+pytestmark = pytest.mark.skipif(
+    not bool(settings.DIGITALOCEAN_KEY), reason="settings missing key and secret"
+)
+
+
+@pytest.fixture(scope="module")
+def storage():
+    driver = DigitalOceanSpacesDriver(
+        settings.DIGITALOCEAN_KEY,
+        settings.DIGITALOCEAN_SECRET,
+        settings.DIGITALOCEAN_REGION,
+    )
+
+    yield driver
+
+    for container in driver:  # cleanup
+        if container.name.startswith(settings.CONTAINER_PREFIX):
+            for blob in container:
+                blob.delete()
+
+            container.delete()
+
+
+# noinspection PyShadowingNames
+def test_driver_create_container(storage):
+    container_name = random_container_name()
+    container = storage.create_container(container_name)
+    assert container_name in storage
+    assert container.name == container_name
+
+
+# noinspection PyShadowingNames
+def test_driver_create_container_invalid_name(storage):
+    # noinspection PyTypeChecker
+    with pytest.raises(CloudStorageError):
+        storage.create_container("?!<>container-name<>!?")  # noqa: W605
+
+
+# noinspection PyShadowingNames
+def test_driver_get_container(storage, container):
+    container_existing = storage.get_container(container.name)
+    assert container_existing.name in storage
+    assert container_existing == container
+
+
+# noinspection PyShadowingNames
+def test_driver_get_container_invalid(storage):
+    container_name = random_container_name()
+
+    # noinspection PyTypeChecker
+    with pytest.raises(NotFoundError):
+        storage.get_container(container_name)
+
+
+# noinspection PyShadowingNames
+def test_container_delete(storage):
+    container_name = random_container_name()
+    container = storage.create_container(container_name)
+    container.delete()
+    assert container.name not in storage
+
+
+def test_container_delete_not_empty(container, text_blob):
+    assert text_blob in container
+
+    # noinspection PyTypeChecker
+    with pytest.raises(IsNotEmptyError):
+        container.delete()
+
+
+def test_container_enable_cdn(container):
+    assert not container.enable_cdn(), "S3 does not support enabling CDN."
+
+
+def test_container_disable_cdn(container):
+    assert not container.disable_cdn(), "S3 does not support disabling CDN."
+
+
+def test_container_cdn_url(container):
+    container.enable_cdn()
+    cdn_url = container.cdn_url
+
+    assert uri_validator(cdn_url)
+    assert container.name in cdn_url
+
+
+def test_container_generate_upload_url(container, binary_stream):
+    form_post = container.generate_upload_url(
+        settings.BINARY_FORM_FILENAME, **settings.BINARY_OPTIONS
+    )
+    assert "url" in form_post and "fields" in form_post
+    assert uri_validator(form_post["url"])
+
+    url = form_post["url"]
+    fields = form_post["fields"]
+    multipart_form_data = {
+        "file": (settings.BINARY_FORM_FILENAME, binary_stream, "image/png"),
+    }
+    response = requests.post(url, data=fields, files=multipart_form_data)
+    assert response.status_code == HTTPStatus.NO_CONTENT, response.text
+
+    blob = container.get_blob(settings.BINARY_FORM_FILENAME)
+    assert blob.meta_data == settings.BINARY_OPTIONS["meta_data"]
+    assert blob.content_type == settings.BINARY_OPTIONS["content_type"]
+
+
+def test_container_generate_upload_url_expiration(container, text_stream):
+    form_post = container.generate_upload_url(settings.TEXT_FORM_FILENAME, expires=-10)
+    assert "url" in form_post and "fields" in form_post
+    assert uri_validator(form_post["url"])
+
+    url = form_post["url"]
+    fields = form_post["fields"]
+    multipart_form_data = {"file": text_stream}
+    response = requests.post(url, data=fields, files=multipart_form_data)
+    assert response.status_code == HTTPStatus.FORBIDDEN, response.text
+
+
+def test_container_get_blob(container, text_blob):
+    blob = container.get_blob(text_blob.name)
+    assert blob == text_blob
+
+
+def test_container_get_blob_invalid(container):
+    blob_name = random_container_name()
+
+    # noinspection PyTypeChecker
+    with pytest.raises(NotFoundError):
+        container.get_blob(blob_name)
+
+
+def test_blob_upload_path(container, text_filename):
+    blob = container.upload_blob(text_filename)
+    assert blob.name == settings.TEXT_FILENAME
+    assert blob.checksum == settings.TEXT_MD5_CHECKSUM
+
+
+def test_blob_upload_pathlib_path(container, text_filename):
+    blob = container.upload_blob(Path(text_filename))
+    assert blob.name == settings.TEXT_FILENAME
+    assert blob.checksum == settings.TEXT_MD5_CHECKSUM
+
+
+def test_blob_upload_stream(container, binary_stream):
+    blob = container.upload_blob(
+        filename=binary_stream,
+        blob_name=settings.BINARY_STREAM_FILENAME,
+        **settings.BINARY_OPTIONS,
+    )
+    assert blob.name == settings.BINARY_STREAM_FILENAME
+    assert blob.checksum == settings.BINARY_MD5_CHECKSUM
+
+
+def test_blob_upload_options(container, binary_stream):
+    blob = container.upload_blob(
+        filename=binary_stream,
+        blob_name=settings.BINARY_STREAM_FILENAME,
+        **settings.BINARY_OPTIONS,
+    )
+    assert blob.name == settings.BINARY_STREAM_FILENAME
+    assert blob.checksum == settings.BINARY_MD5_CHECKSUM
+    assert blob.meta_data == settings.BINARY_OPTIONS["meta_data"]
+    assert blob.content_type == settings.BINARY_OPTIONS["content_type"]
+    assert blob.content_disposition == settings.BINARY_OPTIONS["content_disposition"]
+    assert blob.cache_control == settings.BINARY_OPTIONS["cache_control"]
+
+
+def test_blob_delete(container, text_blob):
+    text_blob.delete()
+    assert text_blob not in container
+
+
+def test_blob_download_path(binary_blob, temp_file):
+    binary_blob.download(temp_file)
+    hash_type = binary_blob.driver.hash_type
+    download_hash = file_checksum(temp_file, hash_type=hash_type)
+    assert download_hash.hexdigest() == settings.BINARY_MD5_CHECKSUM
+
+
+def test_blob_download_pathlib_path(binary_blob, temp_file):
+    binary_blob.download(Path(temp_file))
+    hash_type = binary_blob.driver.hash_type
+    download_hash = file_checksum(temp_file, hash_type=hash_type)
+    assert download_hash.hexdigest() == settings.BINARY_MD5_CHECKSUM
+
+
+def test_blob_download_stream(binary_blob, temp_file):
+    with open(temp_file, "wb") as download_file:
+        binary_blob.download(download_file)
+
+    hash_type = binary_blob.driver.hash_type
+    download_hash = file_checksum(temp_file, hash_type=hash_type)
+    assert download_hash.hexdigest() == settings.BINARY_MD5_CHECKSUM
+
+
+def test_blob_cdn_url(container, binary_blob):
+    container.enable_cdn()
+    cdn_url = binary_blob.cdn_url
+
+    assert uri_validator(cdn_url)
+    assert binary_blob.container.name in cdn_url
+    assert binary_blob.name in cdn_url
+
+
+def test_blob_generate_download_url(binary_blob, temp_file):
+    content_disposition = settings.BINARY_OPTIONS.get("content_disposition")
+    download_url = binary_blob.generate_download_url(
+        content_disposition=content_disposition
+    )
+    assert uri_validator(download_url)
+
+    response = requests.get(download_url)
+    assert response.status_code == HTTPStatus.OK, response.text
+    assert response.headers["content-disposition"] == content_disposition
+
+    with open(temp_file, "wb") as f:
+        for chunk in response.iter_content(chunk_size=128):
+            f.write(chunk)
+
+    hash_type = binary_blob.driver.hash_type
+    download_hash = file_checksum(temp_file, hash_type=hash_type)
+    assert download_hash.hexdigest() == settings.BINARY_MD5_CHECKSUM
+
+
+def test_blob_generate_download_url_expiration(binary_blob):
+    download_url = binary_blob.generate_download_url(expires=-10)
+    assert uri_validator(download_url)
+
+    response = requests.get(download_url)
+    assert response.status_code == HTTPStatus.FORBIDDEN, response.text


### PR DESCRIPTION
DigitalOcean Spaces uses an S3-compatible API, but there are some suble differences.
I made a driver that extends the S3 driver, and I had to do only one small change on it, the "CreateBucketConfiguration" does not work in DigialOcean, so I made it a function that I can override.

I copied the S3 tests, and after some small changes all tests pass.

I am in Windows and tried to test with tox but it is pretty much impossible, maybe Travis will test.
I also didn't find out how to make Travis know of a key to test with DigitalOcean, if that is possible.