### PR TITLE
Adding an atomic local file write

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -16,3 +16,4 @@ Contributors
 * Matt Carr `@matt-carr <https://github.com/matt-carr>`_
 * Sibo Wang `@sibowsb <https://github.com/sibowsb>`_
 * Rangel Reale `@RangelReale <https://github.com/RangelReale>`_
+* Alexander Verbitsky `@habibutsu <https://github.com/habibutsu>`_

--- a/src/cloudstorage/drivers/local.py
+++ b/src/cloudstorage/drivers/local.py
@@ -508,14 +508,18 @@ class LocalDriver(Driver):
         base_path = os.path.dirname(blob_path)
         self._make_path(base_path)
 
+        tmp_blob_path = f'{blob_path}.tmp'
+
         with lock_local_file(blob_path):
             if isinstance(filename, str):
-                shutil.copy(filename, blob_path)
+                shutil.copy(filename, tmp_blob_path)
             else:
-                with open(blob_path, "wb") as blob_file:
+                with open(tmp_blob_path, "wb") as blob_file:
                     for data in filename:
                         blob_file.write(data)
+                    os.fsync(blob_file.fileno())
 
+        os.rename(tmp_blob_path, blob_path)
         # Disable execute mode on file
         os.chmod(blob_path, int("664", 8))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import io
 from tempfile import mkstemp
 
 import pytest
@@ -57,6 +58,14 @@ def binary_filename():
 def binary_stream(binary_filename):
     with open(binary_filename, "rb") as binary_stream:
         yield binary_stream
+
+
+@pytest.fixture(scope="function")
+def binary_bytes():
+    f = io.BytesIO()
+    f.write(b'1' * 1024 * 1024 * 10)
+    f.seek(0)
+    yield f
 
 
 # noinspection PyShadowingNames


### PR DESCRIPTION
In real world processes can terminated unexpectedly, by this reason having guarantees of writing helps to avoid problems with not fully written files.