### PR TITLE
Move pytest config from setup.cfg to pyproject.toml.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,24 @@
 requires = ["setuptools>=35.0.2", "wheel>=0.29.0"]
 build-backend = "setuptools.build_meta"
 
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "-v --tb=short"
+norecursedirs = [
+    ".eggs",
+    ".git",
+    ".pytest_cache",
+    ".tox",
+    "build",
+    "dist",
+    "docs",
+    "env",
+    "venv",
+]
+testpaths = [
+    "tests",
+]
+
 [tool.tox]
 legacy_tox_ini = """
 [tox]

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,16 +21,3 @@ ignore_missing_imports = true
 warn_unreachable = true
 warn_unused_ignores = true
 warn_redundant_casts = true
-
-[tool:pytest]
-norecursedirs =
-    .eggs
-    .git
-    .pytest_cache
-    .tox
-    build
-    dist
-    docs
-    env
-    venv
-addopts = -v --tb=short


### PR DESCRIPTION
#73

 - [x] Move [pytest config](https://docs.pytest.org/en/stable/customize.html#pyproject-toml) to `pyproject.toml`