### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ INSTALL_REQUIRES = [
     "python-magic>=0.4.15",
 ]
 EXTRAS_REQUIRE = {
-    "amazon": ["boto3>=1.8.00", "boto3-stubs[s3]>==1.12.41.0"],
-    "digitalocean": ["boto3>=1.8.00", "boto3-stubs[s3]>==1.12.41.0"],
+    "amazon": ["boto3>=1.8.00", "boto3-stubs[s3]>=1.12.41.0"],
+    "digitalocean": ["boto3>=1.8.00", "boto3-stubs[s3]>=1.12.41.0"],
     "google": ["google-cloud-storage>=1.18.0", "requests>=2.19.1"],
     "local": [
         "filelock>=3.0.0",


### PR DESCRIPTION
Double equal signs cause errors with poetry:

Updating dependencies
Resolving dependencies... (3.8s)
Invalid requirement (boto3-stubs[s3] (>==1.12.41.0) ; extra == 'amazon') found in cloudstorage-0.11.0 dependencies, skipping
Invalid requirement (boto3-stubs[s3] (>==1.12.41.0) ; extra == 'digitalocean') found in cloudstorage-0.11.0 dependencies, skipping
Resolving dependencies... (7.5s)
Invalid requirement (boto3-stubs[s3] (>==1.12.41.0) ; extra == 'amazon') found in cloudstorage-0.11.0 dependencies, skipping
Invalid requirement (boto3-stubs[s3] (>==1.12.41.0) ; extra == 'digitalocean') found in cloudstorage-0.11.0 dependencies, skipping
